### PR TITLE
Avoid creating zombie processes

### DIFF
--- a/lib/gerrit_notifier.rb
+++ b/lib/gerrit_notifier.rb
@@ -73,9 +73,11 @@ class GerritNotifier
     stream = YAML.load(File.read('config/gerrit.yml'))['gerrit']['stream']
     puts "Listening to stream via #{stream}"
 
-    IO.popen(stream).each do |line|
-      update = Update.new(line)
-      process_update(update)
+    IO.popen(stream) do |p|
+      p.each do |line|
+        update = Update.new(line)
+        process_update(update)
+      end
     end
 
     puts "Connection to Gerrit server failed, trying to reconnect."


### PR DESCRIPTION
If the ssh process ended for any reason, a zombie process would be left over.
Passing a block to IO.popen prevents this.
