### PR TITLE
Updating the instantiation of the notifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config/*.yml
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'slack-notifier'
+gem 'slack-notifier', '2.1.0'
 gem 'awesome_print'
 gem 'pry'
 gem 'net-ssh'

--- a/lib/gerrit_notifier.rb
+++ b/lib/gerrit_notifier.rb
@@ -139,7 +139,13 @@ class GerritNotifier
 
     # Merged
     if update.merged?
-      notify channels, "#{update.commit} the patch was merged! \\o/", ":tada: :aw_yeah:"
+      notify channels, "#{update.commit} the patch was merged!", ":tada: :aw_yeah:"
     end
+
+    # Patch abandoned
+    if update.abandoned?
+      notify channels, "The following patchset has been abandoned: #{update.commit}."
+    end
+
   end
 end

--- a/lib/gerrit_notifier.rb
+++ b/lib/gerrit_notifier.rb
@@ -51,7 +51,7 @@ class GerritNotifier
 
           if @@buffer.size > 0 && !ENV['DEVELOPMENT']
             @@buffer.each do |channel, messages|
-              notifier = Slack::Notifier.new slack_config['team'], slack_config['token']
+              notifier = Slack::Notifier.new slack_config['token']
               notifier.ping(messages.join("\n\n"),
                 channel: channel,
                 username: 'gerrit',

--- a/lib/gerrit_notifier.rb
+++ b/lib/gerrit_notifier.rb
@@ -55,7 +55,7 @@ class GerritNotifier
               notifier.ping(messages.join("\n\n"),
                 channel: channel,
                 username: 'gerrit',
-                icon_emoji: ':dragon_face:',
+                icon_emoji: ':gerrit:',
                 link_names: 1
               )
             end
@@ -93,6 +93,11 @@ class GerritNotifier
 
     return if channels.size == 0
 
+    # New patchset
+    if update.new_patchset? && !update.wip?
+      notify channels, "@here, a new patchset has been created: #{update.commit}. Needs *code review*"
+    end
+
     # Jenkins update
     if update.jenkins?
       if update.build_successful? && !update.wip?
@@ -104,12 +109,12 @@ class GerritNotifier
 
     # Code review +2
     if update.code_review_approved?
-      notify channels, "#{update.author_slack_name} has *+2'd* #{update.commit}: ready for *QA*"
+      notify channels, "#{update.author_slack_name} has *+2'd* #{update.commit}: the patch is ready to be *submitted*"
     end
 
     # Code review +1
     if update.code_review_tentatively_approved?
-      notify channels, "#{update.author_slack_name} has *+1'd* #{update.commit}: needs another set of eyes for *code review*"
+      notify channels, "#{update.author_slack_name} has *+1'd* #{update.commit}"
     end
 
     # QA/Product
@@ -124,7 +129,7 @@ class GerritNotifier
     # Any minuses (Code/Product/QA)
     if update.minus_1ed? || update.minus_2ed?
       verb = update.minus_1ed? ? "-1'd" : "-2'd"
-      notify channels, "#{update.author_slack_name} has *#{verb}* #{update.commit}"
+      notify channels, "#{update.author_slack_name} has *#{verb}* #{update.commit}", ":slowclap:"
     end
 
     # New comment added
@@ -134,7 +139,7 @@ class GerritNotifier
 
     # Merged
     if update.merged?
-      notify channels, "#{update.commit} was merged! \\o/", ":yuss: :dancing_cool:"
+      notify channels, "#{update.commit} the patch was merged! \\o/", ":tada: :aw_yeah:"
     end
   end
 end

--- a/lib/update.rb
+++ b/lib/update.rb
@@ -16,6 +16,10 @@ class Update
     json['change']['project'] if json['change']
   end
 
+  def new_patchset?
+    type == 'patchset-created'
+  end
+
   def comment_added?
     type == 'comment-added'
   end

--- a/lib/update.rb
+++ b/lib/update.rb
@@ -28,6 +28,10 @@ class Update
     type == 'change-merged'
   end
 
+  def abandoned?
+    type == 'change-abandoned'
+  end
+
   def human?
     !['hudson', 'firework'].include?(json['author']['username'])
   end


### PR DESCRIPTION
When creating an instance of the slack notifier, a parameter for
the team was being used. That is no longer needd, this commit
updates that.

Also, when I first installed the project it didn't work, cause
it installed slack-notifier gem version 0.5, which is very old,
this patch fixes the gem version to be the latest.